### PR TITLE
Add Deno volunteer shift app skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PORT=8000
+DATABASE_URL=postgres://user:password@localhost:5432/theatre
+SESSION_SECRET=your-secret
+RESEND_API_KEY=your-resend-api-key
+BASE_URL=http://localhost:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM denoland/deno:alpine-1.36.0
+WORKDIR /app
+COPY . .
+RUN deno cache src/main.ts
+CMD ["run", "-A", "src/main.ts"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Volunteer Shift App for Theatre
+
+This is a simple full-stack application built with **Deno** and **TypeScript**. It allows theatre staff to manage shows, volunteers and shifts, and lets volunteers sign up for shifts via a shareable link.
+
+## Features
+- Admin login via token authentication
+- Manage shows, shifts and volunteers
+- Volunteer signup page (mobile friendly)
+- Basic analytics to list unfilled shifts
+
+## Requirements
+- Deno v2.3+
+- PostgreSQL database
+
+## Setup
+1. Copy `.env.example` to `.env` and fill in the values.
+2. Create the database and run the SQL in `db/schema.sql`.
+3. Start the server:
+   ```bash
+   deno run -A src/main.ts
+   ```
+
+## Docker
+A basic Dockerfile is provided. Build and run with:
+```bash
+docker build -t theatre-app .
+docker run -p 8000:8000 --env-file .env theatre-app
+```

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS shows (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  date DATE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS volunteers (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT,
+  phone TEXT
+);
+
+CREATE TABLE IF NOT EXISTS shifts (
+  id SERIAL PRIMARY KEY,
+  show_id INTEGER REFERENCES shows(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  start_time TIMESTAMP NOT NULL,
+  end_time TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS volunteer_shifts (
+  volunteer_id INTEGER REFERENCES volunteers(id) ON DELETE CASCADE,
+  shift_id INTEGER REFERENCES shifts(id) ON DELETE CASCADE,
+  PRIMARY KEY (volunteer_id, shift_id)
+);

--- a/src/controllers/admin.ts
+++ b/src/controllers/admin.ts
@@ -1,0 +1,139 @@
+import { Context } from "https://deno.land/x/oak@12.6.1/mod.ts";
+import { getPool } from "../models/db.ts";
+import { hash } from "https://deno.land/x/bcrypt@0.4.1/mod.ts";
+
+export async function login(ctx: Context) {
+  const { value } = await ctx.request.body({ type: "json" });
+  const { username, password } = await value;
+  // TODO: replace with real authentication check
+  if (username === Deno.env.get("ADMIN_USER") && password === Deno.env.get("ADMIN_PASS")) {
+    ctx.response.status = 200;
+    ctx.response.body = { success: true };
+  } else {
+    ctx.response.status = 401;
+    ctx.response.body = { error: "Unauthorized" };
+  }
+}
+
+export async function listShows(ctx: Context) {
+  const pool = getPool();
+  const result = await pool.queryObject("SELECT * FROM shows ORDER BY date");
+  ctx.response.body = result.rows;
+}
+
+export async function createShow(ctx: Context) {
+  const { value } = await ctx.request.body({ type: "json" });
+  const { name, date } = await value;
+  const pool = getPool();
+  await pool.queryObject("INSERT INTO shows (name, date) VALUES ($1, $2)", [name, date]);
+  ctx.response.status = 201;
+}
+
+export async function updateShow(ctx: Context) {
+  const id = ctx.params.id;
+  const { value } = await ctx.request.body({ type: "json" });
+  const { name, date } = await value;
+  const pool = getPool();
+  await pool.queryObject("UPDATE shows SET name=$1, date=$2 WHERE id=$3", [name, date, id]);
+  ctx.response.status = 204;
+}
+
+export async function deleteShow(ctx: Context) {
+  const id = ctx.params.id;
+  const pool = getPool();
+  await pool.queryObject("DELETE FROM shows WHERE id=$1", [id]);
+  ctx.response.status = 204;
+}
+
+export async function listVolunteers(ctx: Context) {
+  const pool = getPool();
+  const result = await pool.queryObject("SELECT * FROM volunteers ORDER BY name");
+  ctx.response.body = result.rows;
+}
+
+export async function createVolunteer(ctx: Context) {
+  const { value } = await ctx.request.body({ type: "json" });
+  const { name, email, phone } = await value;
+  const pool = getPool();
+  const res = await pool.queryObject<{ id: number }>(
+    "INSERT INTO volunteers (name, email, phone) VALUES ($1, $2, $3) RETURNING id",
+    [name, email, phone],
+  );
+  const id = res.rows[0].id;
+  ctx.response.status = 201;
+  ctx.response.body = { id, signupLink: `${Deno.env.get("BASE_URL")}/volunteer/signup/${id}` };
+}
+
+export async function getVolunteer(ctx: Context) {
+  const id = ctx.params.id;
+  const pool = getPool();
+  const result = await pool.queryObject("SELECT * FROM volunteers WHERE id=$1", [id]);
+  if (result.rows.length === 0) {
+    ctx.throw(404, "Volunteer not found");
+  }
+  ctx.response.body = result.rows[0];
+}
+
+export async function updateVolunteer(ctx: Context) {
+  const id = ctx.params.id;
+  const { value } = await ctx.request.body({ type: "json" });
+  const { name, email, phone } = await value;
+  const pool = getPool();
+  await pool.queryObject("UPDATE volunteers SET name=$1, email=$2, phone=$3 WHERE id=$4", [name, email, phone, id]);
+  ctx.response.status = 204;
+}
+
+export async function deleteVolunteer(ctx: Context) {
+  const id = ctx.params.id;
+  const pool = getPool();
+  await pool.queryObject("DELETE FROM volunteers WHERE id=$1", [id]);
+  ctx.response.status = 204;
+}
+
+export async function listShifts(ctx: Context) {
+  const pool = getPool();
+  const result = await pool.queryObject("SELECT * FROM shifts ORDER BY start_time");
+  ctx.response.body = result.rows;
+}
+
+export async function createShift(ctx: Context) {
+  const { value } = await ctx.request.body({ type: "json" });
+  const { show_id, role, start_time, end_time } = await value;
+  const pool = getPool();
+  await pool.queryObject(
+    "INSERT INTO shifts (show_id, role, start_time, end_time) VALUES ($1, $2, $3, $4)",
+    [show_id, role, start_time, end_time],
+  );
+  ctx.response.status = 201;
+}
+
+export async function updateShift(ctx: Context) {
+  const id = ctx.params.id;
+  const { value } = await ctx.request.body({ type: "json" });
+  const { role, start_time, end_time } = await value;
+  const pool = getPool();
+  await pool.queryObject(
+    "UPDATE shifts SET role=$1, start_time=$2, end_time=$3 WHERE id=$4",
+    [role, start_time, end_time, id],
+  );
+  ctx.response.status = 204;
+}
+
+export async function deleteShift(ctx: Context) {
+  const id = ctx.params.id;
+  const pool = getPool();
+  await pool.queryObject("DELETE FROM shifts WHERE id=$1", [id]);
+  ctx.response.status = 204;
+}
+
+export async function unfilledShifts(ctx: Context) {
+  const pool = getPool();
+  const result = await pool.queryObject(
+    `SELECT s.*, COUNT(vs.volunteer_id) as filled
+     FROM shifts s
+     LEFT JOIN volunteer_shifts vs ON vs.shift_id = s.id
+     GROUP BY s.id
+     HAVING COUNT(vs.volunteer_id) = 0`
+  );
+  ctx.response.body = result.rows;
+}

--- a/src/controllers/volunteer.ts
+++ b/src/controllers/volunteer.ts
@@ -1,0 +1,43 @@
+import { Context } from "https://deno.land/x/oak@12.6.1/mod.ts";
+import { getPool } from "../models/db.ts";
+import { render } from "../utils/template.ts";
+
+export async function viewSignup(ctx: Context) {
+  const id = ctx.params.id;
+  const pool = getPool();
+  const volunteerRes = await pool.queryObject("SELECT * FROM volunteers WHERE id=$1", [id]);
+  if (volunteerRes.rows.length === 0) {
+    ctx.throw(404, "Volunteer not found");
+  }
+
+  const shiftsRes = await pool.queryObject(
+    `SELECT s.* FROM shifts s
+     LEFT JOIN volunteer_shifts vs ON vs.shift_id = s.id AND vs.volunteer_id = $1
+     WHERE vs.volunteer_id IS NULL`,
+    [id],
+  );
+
+  const html = await render(
+    "views/signup.html",
+    {
+      name: volunteerRes.rows[0].name,
+      shifts: JSON.stringify(shiftsRes.rows),
+    },
+  );
+  ctx.response.headers.set("Content-Type", "text/html; charset=utf-8");
+  ctx.response.body = html;
+}
+
+export async function submitSignup(ctx: Context) {
+  const id = ctx.params.id;
+  const { value } = await ctx.request.body({ type: "json" });
+  const { shiftIds } = await value;
+  const pool = getPool();
+  for (const shiftId of shiftIds) {
+    await pool.queryObject(
+      "INSERT INTO volunteer_shifts (volunteer_id, shift_id) VALUES ($1, $2)",
+      [id, shiftId],
+    );
+  }
+  ctx.response.status = 201;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,19 @@
+import { Application } from "https://deno.land/x/oak@12.6.1/mod.ts";
+import { oakCors } from "https://deno.land/x/cors@v1.2.2/mod.ts";
+import { load } from "https://deno.land/std@0.203.0/dotenv/mod.ts";
+
+import router from "./routes/index.ts";
+import { initDb } from "./models/db.ts";
+
+const env = await load({ export: true });
+const port = parseInt(Deno.env.get("PORT") ?? "8000");
+
+await initDb();
+
+const app = new Application();
+app.use(oakCors());
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+console.log(`Server running on http://localhost:${port}`);
+await app.listen({ port });

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,11 @@
+import { Context, Status } from "https://deno.land/x/oak@12.6.1/mod.ts";
+
+export async function requireAuth(ctx: Context, next: () => Promise<unknown>) {
+  const auth = ctx.request.headers.get("authorization");
+  if (!auth || auth !== `Bearer ${Deno.env.get("ADMIN_TOKEN")}`) {
+    ctx.response.status = Status.Unauthorized;
+    ctx.response.body = { error: "Unauthorized" };
+    return;
+  }
+  await next();
+}

--- a/src/models/db.ts
+++ b/src/models/db.ts
@@ -1,0 +1,14 @@
+import { Pool } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
+
+let pool: Pool;
+
+export function getPool() {
+  if (!pool) throw new Error("Database not initialized");
+  return pool;
+}
+
+export async function initDb() {
+  const connectionString = Deno.env.get("DATABASE_URL");
+  if (!connectionString) throw new Error("DATABASE_URL not set");
+  pool = new Pool(connectionString, 10, true);
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,27 @@
+import { Router } from "https://deno.land/x/oak@12.6.1/mod.ts";
+import * as adminController from "../controllers/admin.ts";
+import { requireAuth } from "../middlewares/auth.ts";
+
+const router = new Router();
+
+router.post("/login", adminController.login);
+router.use(requireAuth);
+router.get("/shows", adminController.listShows);
+router.post("/shows", adminController.createShow);
+router.put("/shows/:id", adminController.updateShow);
+router.delete("/shows/:id", adminController.deleteShow);
+
+router.get("/volunteers", adminController.listVolunteers);
+router.post("/volunteers", adminController.createVolunteer);
+router.get("/volunteers/:id", adminController.getVolunteer);
+router.put("/volunteers/:id", adminController.updateVolunteer);
+router.delete("/volunteers/:id", adminController.deleteVolunteer);
+
+router.get("/shifts", adminController.listShifts);
+router.post("/shifts", adminController.createShift);
+router.put("/shifts/:id", adminController.updateShift);
+router.delete("/shifts/:id", adminController.deleteShift);
+
+router.get("/analytics/unfilled", adminController.unfilledShifts);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,9 @@
+import { Router } from "https://deno.land/x/oak@12.6.1/mod.ts";
+import adminRouter from "./admin.ts";
+import volunteerRouter from "./volunteer.ts";
+
+const router = new Router();
+router.use("/admin", adminRouter.routes(), adminRouter.allowedMethods());
+router.use("/volunteer", volunteerRouter.routes(), volunteerRouter.allowedMethods());
+
+export default router;

--- a/src/routes/volunteer.ts
+++ b/src/routes/volunteer.ts
@@ -1,0 +1,9 @@
+import { Router } from "https://deno.land/x/oak@12.6.1/mod.ts";
+import * as volunteerController from "../controllers/volunteer.ts";
+
+const router = new Router();
+
+router.get("/signup/:id", volunteerController.viewSignup);
+router.post("/signup/:id", volunteerController.submitSignup);
+
+export default router;

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -1,0 +1,6 @@
+import Mustache from "https://deno.land/x/mustache@v0.3.0/mod.ts";
+
+export async function render(templatePath: string, data: Record<string, unknown>) {
+  const template = await Deno.readTextFile(templatePath);
+  return Mustache.render(template, data);
+}

--- a/views/signup.html
+++ b/views/signup.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Volunteer Signup</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 1rem; }
+    .shift { margin-bottom: 0.5rem; }
+    button { padding: 0.5rem 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Hello, {{name}}</h1>
+  <form id="signupForm">
+    <div id="shifts"></div>
+    <button type="submit">Submit</button>
+  </form>
+  <script>
+    const shifts = {{shifts}};
+    const container = document.getElementById('shifts');
+    shifts.forEach(s => {
+      const div = document.createElement('div');
+      div.className = 'shift';
+      div.innerHTML = `<label><input type='checkbox' value='${s.id}'> ${s.role} (${s.start_time})</label>`;
+      container.appendChild(div);
+    });
+    document.getElementById('signupForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const ids = Array.from(document.querySelectorAll('input[type=checkbox]:checked')).map(cb => cb.value);
+      await fetch(window.location.href, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({shiftIds: ids})
+      });
+      alert('Thank you for signing up!');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Deno backend with Oak router and Postgres
- add admin and volunteer controllers with routes
- add volunteer signup HTML template and util renderer
- add schema.sql, Dockerfile, and README instructions

## Testing
- `deno fmt --check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685793888af8832dba094f26b6b2cc64